### PR TITLE
Support building on Mac, and add CI runners to test builds

### DIFF
--- a/.github/actions/elixir-setup/action.yml
+++ b/.github/actions/elixir-setup/action.yml
@@ -1,0 +1,132 @@
+name: Setup Elixir Project
+description: Checks out the code, configures Elixir, fetches dependencies, and manages build caching.
+inputs:
+  elixir-version:
+    required: true
+    type: string
+    description: Elixir version to set up
+  otp-version:
+    required: true
+    type: string
+    description: OTP version to set up
+  #################################################################
+  # Everything below this line is optional.
+  #
+  # It's designed to make compiling a reasonably standard Elixir
+  # codebase "just work," though there may be speed gains to be had
+  # by tweaking these flags.
+  #################################################################
+  build-deps:
+    required: false
+    type: boolean
+    default: true
+    description: True if we should compile dependencies
+  build-app:
+    required: false
+    type: boolean
+    default: true
+    description: True if we should compile the application itself
+  build-flags:
+    required: false
+    type: string
+    default: '--all-warnings'
+    description: Flags to pass to mix compile
+  install-rebar:
+    required: false
+    type: boolean
+    default: true
+    description: By default, we will install Rebar (mix local.rebar --force).
+  install-hex:
+    required: false
+    type: boolean
+    default: true
+    description: By default, we will install Hex (mix local.hex --force).
+  cache-key:
+    required: false
+    type: string
+    default: 'v1'
+    description: If you need to reset the cache for some reason, you can change this key.
+outputs:
+  otp-version:
+    description: "Exact OTP version selected by the BEAM setup step"
+    value: ${{ steps.beam.outputs.otp-version }}
+  elixir-version:
+    description: "Exact Elixir version selected by the BEAM setup step"
+    value: ${{ steps.beam.outputs.elixir-version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Setup elixir
+      uses: erlef/setup-beam@v1
+      id: beam
+      with:
+        elixir-version: ${{ inputs.elixir-version }}
+        otp-version: ${{ inputs.otp-version }}
+
+    - name: Get deps cache
+      uses: actions/cache@v3
+      with:
+        path: deps/
+        key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          deps-${{ inputs.cache-key }}-${{ runner.os }}-
+
+    - name: Get build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: _build/${{env.MIX_ENV}}/
+        key: build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
+
+    - name: Get Hex cache
+      uses: actions/cache@v2
+      id: hex-cache
+      with:
+        path: ~/.hex
+        key: build-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          build-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-
+
+    # In my experience, I have issues with incremental builds maybe 1 in 100
+    # times that are fixed by doing a full recompile.
+    # In order to not waste dev time on such trivial issues (while also reaping
+    # the time savings of incremental builds for *most* day-to-day development),
+    # I force a full recompile only on builds that we retry.
+    - name: Clean to rule out incremental build as a source of flakiness
+      if: github.run_attempt != '1'
+      run: | 
+        mix deps.clean --all
+        mix clean
+      shell: sh
+
+    - name: Install Rebar
+      run: mix local.rebar --force
+      shell: sh
+      if: inputs.install-rebar == 'true'
+
+    - name: Install Hex
+      run: mix local.hex --force
+      shell: sh
+      if: inputs.install-hex == 'true'
+
+    - name: Install Dependencies
+      run: mix deps.get
+      shell: sh
+
+    # Normally we'd use `mix deps.compile` here, however that incurs a large
+    # performance penalty when the dependencies are already fully compiled:
+    # https://elixirforum.com/t/github-action-cache-elixir-always-recompiles-dependencies-elixir-1-13-3/45994/12
+    #
+    # Accoring to Jose Valim at the above link `mix loadpaths` will check and
+    # compile missing dependencies
+    - name: Compile Dependencies
+      run: mix loadpaths
+      shell: sh
+      if: inputs.build-deps == 'true'
+
+    - name: Compile Application
+      run: mix compile ${{ inputs.build-flags }}
+      shell: sh
+      if: inputs.build-app == 'true'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: mix
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "12:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -1,0 +1,33 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-22.04
+    env:
+      MIX_ENV: test
+      elixir: "1.15.7"
+      otp: "26.1.2"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Elixir Project
+        uses: ./.github/actions/elixir-setup
+        with:
+          elixir-version: ${{ env.elixir }}
+          otp-version: ${{ env.otp }}
+          build-flags: --all-warnings --warnings-as-errors
+
+      - name: Run Tests
+        run: mix test --warnings-as-errors
+        if: always()

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -9,8 +9,8 @@ on:
       - '*'
 
 jobs:
-  build:
-    name: Build and test
+  build_linux:
+    name: Build and test on Linux
     runs-on: ubuntu-22.04
     env:
       MIX_ENV: test
@@ -27,6 +27,26 @@ jobs:
           elixir-version: ${{ env.elixir }}
           otp-version: ${{ env.otp }}
           build-flags: --all-warnings --warnings-as-errors
+
+      - name: Run Tests
+        run: mix test --warnings-as-errors
+        if: always()
+
+  build_mac:
+    name: Build and test on Mac
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Elixir Project
+        run: brew install elixir
+
+      - name: Get deps
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile --all-warnings --warnings-as-errors
 
       - name: Run Tests
         run: mix test --warnings-as-errors

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ex_brotli-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 /priv/brotli_nif.so
+/priv/brotli_nif.so.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ CXXFLAGS = --std=c++17 -g -O3 -Wall -Wno-format-truncation
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS += -I"$(ERLANG_PATH)" -Ic_src -Ideps/brotli/c/include -fPIC
 CXXFLAGS += -I"$(ERLANG_PATH)" -Ic_src -Ideps/brotli/c/include -fPIC
-MACOS_FLAGS = -bundle -bundle_loader "$(ERLANG_PATH)"/../bin/beam.smp
+
+OS_FLAGS = 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	OS_FLAGS += -bundle -bundle_loader "$(ERLANG_PATH)"/../bin/beam.smp
+else
+	OS_FLAGS += -shared
+endif
+
 #LDFLAGS += --whole-file
 
 LIB_NAME = priv/brotli_nif.so
@@ -18,11 +26,11 @@ all: $(LIB_NAME)
 
 $(LIB_NAME): $(NIF_SRC) $(LIB_EXT)
 	mkdir -p priv
-	$(CC) $(CFLAGS) $(MACOS_FLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $(OS_FLAGS) $^ -o $@
 
 $(LIB_EXT):
 	if [ ! -d "deps" ]; then mkdir deps; fi
-	cd deps; if [ ! -d "brotli" ]; then git clone https://github.com/google/brotli.git; fi
+	cd deps; if [ ! -d "brotli" ]; then git clone https://github.com/google/brotli.git; fi ; cd ..
 # v1.0.9, just before they changed the build process
 	cd deps/brotli ; git checkout e61745a
 	if [ ! -d "deps/brotli/out" ]; then mkdir deps/brotli/out ; fi

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 CFLAGS = -g -O3 -Wall -Wno-format-truncation
 CXXFLAGS = --std=c++17 -g -O3 -Wall -Wno-format-truncation
 
+# ERLANG_PATH is something like ERL_ROOT=/opt/homebrew/Cellar/erlang/26.0.2/lib/erlang/include
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS += -I"$(ERLANG_PATH)" -Ic_src -Ideps/brotli/c/include -fPIC
 CXXFLAGS += -I"$(ERLANG_PATH)" -Ic_src -Ideps/brotli/c/include -fPIC
+MACOS_FLAGS = -bundle -bundle_loader "$(ERLANG_PATH)"/../bin/beam.smp
 #LDFLAGS += --whole-file
 
 LIB_NAME = priv/brotli_nif.so
@@ -16,11 +18,13 @@ all: $(LIB_NAME)
 
 $(LIB_NAME): $(NIF_SRC) $(LIB_EXT)
 	mkdir -p priv
-	$(CC) $(CFLAGS) -shared $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(MACOS_FLAGS) $^ -o $@
 
 $(LIB_EXT):
 	if [ ! -d "deps" ]; then mkdir deps; fi
 	cd deps; if [ ! -d "brotli" ]; then git clone https://github.com/google/brotli.git; fi
+# v1.0.9, just before they changed the build process
+	cd deps/brotli ; git checkout e61745a
 	if [ ! -d "deps/brotli/out" ]; then mkdir deps/brotli/out ; fi
 	cd deps/brotli/out ; CFLAGS="-fPIC" ../configure-cmake ; make
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExBrotli.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:elixir_make, "~> 0.6.2", runtime: false}
+      {:elixir_make, "~> 0.7", runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
+  "elixir_make": {:hex, :elixir_make, "0.7.7", "7128c60c2476019ed978210c245badf08b03dbec4f24d05790ef791da11aa17c", [:mix], [{:castore, "~> 0.1 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm", "5bc19fff950fad52bbe5f211b12db9ec82c6b34a9647da0c2224b8b8464c7e6c"},
 }


### PR DESCRIPTION
Hi there! Thanks so much for this project—in my experience, it's compatible with way more Brotli-encoded web pages out in the wild than the [native Erlang implementation](https://github.com/yjh0502/erl-brotli).

This PR addresses a few pain points I had while trying to integrate the library into my project:

- adds `OS_FLAGS` to the `Makefile` to support Mac builds—not necessary for most people's deployments, but a common need for development environments
- adds CI jobs to build and run `mix test` on both Mac and Linux
- pins Brotli to the most recent version that's compatible with the rest of the Makefile (newer versions require CMake, and it wasn't clear to me at all how to get it to work)
- takes the latest version of `elixir_make` (mostly to keep compatibility with other recent packages)